### PR TITLE
Fix bower asset path

### DIFF
--- a/src/LightboxAsset.php
+++ b/src/LightboxAsset.php
@@ -6,7 +6,7 @@ use yii\web\AssetBundle;
 
 class LightboxAsset extends AssetBundle {
 
-    public $sourcePath = '@bower/lightbox2';
+    public $sourcePath = '@bower/bower-asset/lightbox2';
 
     public $js = [
         'js/lightbox.min.js',


### PR DESCRIPTION
Apparently the asset files are below `vendor/bower/bower-asset` instead of just `vendor/bower`, see composer.json
